### PR TITLE
Waiting loop kernel module to be loaded

### DIFF
--- a/groot-btrfs-release/jobs/groot-btrfs/templates/bin/init-store.erb
+++ b/groot-btrfs-release/jobs/groot-btrfs/templates/bin/init-store.erb
@@ -48,24 +48,17 @@ create_and_mount_filesystem() {
 
   mkfs.btrfs -f "${backing_store_file}"
 
-  # It is possible for the filesystem creation to take some more time
-  # in the background when reaching the mount, causing it to fail.
-  # Simply repeat the attempt. But not too often, i.e. not too long.
-
-  trials=15
-  sleep_time=2
-  count=$trials
-  until mount -t btrfs -o user_subvol_rm_allowed "${backing_store_file}" "${1}"
-  do
-      count=$(( count - 1 ))
-      if test $count -eq 0 ; then
-	  echo New filesystem has not become ready within $trials attempts, about $(( trials * sleep_time )) seconds.
-	  echo Aborting.
-	  exit 1
-      fi
-      echo Waiting for the new filesystem to be ready
-      sleep $sleep_time
-  done
+  local logfile="/var/log/create_and_mount_filesystem.log"
+  if ! mount -t btrfs -o loop,user_subvol_rm_allowed "${backing_store_file}" "${1}" 2> "${logfile}"; then
+    set +x
+    cat "${logfile}"
+    if grep --silent "failed to setup loop device" < "${logfile}"; then
+      printf "Waiting for the loop kernel module to be loaded..."
+      until grep --silent "loop" < "/proc/modules"; do sleep 1; done;
+      printf " done; bailing out for container restart.\\n"
+    fi
+    exit 1
+  fi
 
   btrfs quota enable "${1}"
 }


### PR DESCRIPTION
## Description

Mounting a file as a filesystem requires the loop devices to be present. When mount is called, it implicitly uses `-o loop`, but the loop kernel module only gets loaded when it is required for the first time. On SCF, the mount happens inside a container using the host kernel, and it is not able to see the loop devices under `/dev/loop*`, which makes the mount impossible, even though the module loads successfully.

The changes here will do the following:
- Call mount and save the errors to a log file.
- Print the log file.
- Check on the log file if the error is related to the loop device.
- Wait for the kernel to load the loop module (triggered by the mount call).
- Prints a meaningful message for the user.
- Exit with 1.
